### PR TITLE
Add support for matrix release zips

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,15 @@ This is equivalent to the **branch** name where your addon lives in the official
 
 **Required** A secret containing your email address. This is used in `git config` to submit the pull request.
 
+## Outputs
+
+### `addon-zip`
+
+Path to the addon release zip file
+
+### `addon-zip-matrix`
+
+Path to the addon release zip file for matrix (if `kodi-matrix` input is `true`). This zip uses PEP440 local version identifier.
 
 ## Example usage
 

--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,8 @@ inputs:
 outputs:
     addon-zip:
         description: 'The path to the zip file of the addon'
+    addon-zip-matrix:
+        description: 'The path to the zip file of the addon release for matrix (PEP440 local version identifier) if kodi-matrix input is true.'
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,8 +1,14 @@
 #!/bin/sh -l
-submit-addon -z $3
-echo ::set-output name=addon-zip::$(ls *.zip)
 if [ "$4" = true ] ; then
+  # addon zip
+  submit-addon -z $3 -m
+  echo ::set-output name=addon-zip::$(ls *.zip | awk '$0 !~ /\+matrix\./')
+  echo ::set-output name=addon-zip-matrix::$(ls *+matrix*.zip)
+  # addon pull request
   submit-addon -r $1 -b $2 --pull-request $3 -m
 else
+  submit-addon -z $3
+  echo ::set-output name=addon-zip::$(ls *.zip)
+  echo ::set-output name=addon-zip-matrix::
   submit-addon -r $1 -b $2 --pull-request $3
 fi


### PR DESCRIPTION
Also creates a release zip for matrix and exports it as an output, so that we can upload the two addon zip files to github releases tab

Needs https://github.com/romanvm/kodi-addon-submitter/pull/11 to be merged first